### PR TITLE
note about usage requiring feature flag would be nice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ pool.
 
 # Example
 
+```
+cargo run --example usage --features rust-argon2
+```
+
+
 ```rust
 use axum_password_worker::{BcryptConfig, PasswordWorker};
 


### PR DESCRIPTION
https://www.youtube.com/watch?v=FJsBGiRTM9A this PR breaks the test so it's not acceptable, I'd be happy to change it to resolve the test.  Nice idea.  Removing the ticks of course fixes the error; is there a way to do a informational tick'd block that isn't tested?  Should the app run when no features are specified?  The readme says they are optional features.

```
    Finished test [unoptimized + debuginfo] target(s) in 1.40s
   Doc-tests axum-password-worker

running 5 tests
test src\lib.rs - (line 17) ... FAILED
test src\worker.rs - worker::PasswordWorker<H>::new (line 56) ... ok
test src\worker.rs - worker::PasswordWorker<H>::hash (line 98) ... ok
test src\lib.rs - (line 22) ... ok
test src\worker.rs - worker::PasswordWorker<H>::verify (line 130) ... ok

failures:

---- src\lib.rs - (line 17) stdout ----
error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `run`
 --> src\lib.rs:18:7
  |
3 | cargo run --example usage --features rust-argon2
  |       ^^^ expected one of 8 possible tokens

error: aborting due to previous error

Couldn't compile the test.

failures:
    src\lib.rs - (line 17)

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.71s
```